### PR TITLE
More key bindings: w rotates, s moves down

### DIFF
--- a/tetris.py
+++ b/tetris.py
@@ -223,6 +223,8 @@ def run_gui():
     root.bind("<Right>", tetris_control.move_block_right)
     root.bind("<Up>", tetris_control.rotate_block)
     root.bind("<p>", tetris_control.pause_game)
+    root.bind("<w>", tetris_control.rotate_block)
+    root.bind("<s>", tetris_control.move_block_down_press)
     root.bind("<Down>", tetris_control.move_block_down_press)
     root.bind("<KeyRelease-Down>", tetris_control.move_block_down_release)
 

--- a/tetris.py
+++ b/tetris.py
@@ -225,6 +225,7 @@ def run_gui():
     root.bind("<p>", tetris_control.pause_game)
     root.bind("<w>", tetris_control.rotate_block)
     root.bind("<s>", tetris_control.move_block_down_press)
+    # No binding for releasing the s key, so that the block moves down until it lands
     root.bind("<Down>", tetris_control.move_block_down_press)
     root.bind("<KeyRelease-Down>", tetris_control.move_block_down_release)
 


### PR DESCRIPTION
I use the mouse with my right hand. This means that when moving blocks sideways with mouse wheel (#79), I need to use my left hand to rotate the blocks and move them down, so the arrow keys are in a bit inconvenient place.

w is just like the arrow up.

s is just like arrow down, except that it moves down all the way, as opposed to moving down until you release the arrow key. This is done by not adding a `KeyRelease` binding which would stop moving the block before it lands. If this is unacceptable and you want arrow down and `s` to behave the same, let me know.